### PR TITLE
`ISSUE_TEMPLATE.md`: incorporate native JSON viewer from Edge

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@
 <!--
  - Report a *bug* with browser version
  - For Firefox users - is `devtools.jsonview.enabled` set to `false` in about:config page?
+ - For Edge users - is `edge://flags/#edge-json-viewer` set to `Disabled`?
  - Feel free to delete this template
 -->
 


### PR DESCRIPTION
JSON Lite in Edge can only work if the [native JSON viewer from Edge](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/json-viewer/json-viewer) is disabled in `edge://flags/#edge-json-viewer`.